### PR TITLE
Inject formula version to sbt build and set SN_RELEASE=size

### DIFF
--- a/Formula/plutus.rb
+++ b/Formula/plutus.rb
@@ -4,6 +4,7 @@ class Plutus < Formula
   url "https://github.com/dhpiggott/plutus/archive/refs/tags/v2.tar.gz"
   sha256 "9f7c3643628b582c0590fa88d7e768f46f75c83e6800a0daad33341b901c1d90"
   license ""
+  revision 1
 
   bottle do
     root_url "https://github.com/dhpiggott/homebrew-tap/releases/download/plutus-2"
@@ -17,7 +18,8 @@ class Plutus < Formula
   depends_on "s2n"
 
   def install
-    system "sbt", "plutus/nativeLink"
+    ENV["SN_RELEASE"] = "size"
+    system "sbt", "set ThisBuild/version := \"#{version}\"", "plutus/nativeLink"
     bin.install "plutus/target/plutus-out" => "plutus"
   end
 end

--- a/Formula/plutus.rb
+++ b/Formula/plutus.rb
@@ -18,7 +18,6 @@ class Plutus < Formula
   depends_on "s2n"
 
   def install
-    ENV["SN_RELEASE"] = "size"
     system "sbt", "set ThisBuild/version := \"#{version}\"", "plutus/nativeLink"
     bin.install "plutus/target/plutus-out" => "plutus"
   end


### PR DESCRIPTION
We need to inject the version this way because otherwise the sbt build uses dynver to infer it based on Git tags but gets it wrong because the expected tags aren't present in the homebrew-tap repo.

SN_RELEASE=size should have been included before - omitting it was an error.